### PR TITLE
Removed number column from migration and from import_projects rake task

### DIFF
--- a/db/migrate/20171102155207_create_projects.rb
+++ b/db/migrate/20171102155207_create_projects.rb
@@ -1,7 +1,6 @@
 class CreateProjects < ActiveRecord::Migration[5.1]
   def change
     create_table :projects do |t|
-      t.integer :number
       t.text :project_title
       t.string :donors, null: false
       t.string :status, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,6 @@ ActiveRecord::Schema.define(version: 20171102155207) do
   enable_extension "plpgsql"
 
   create_table "projects", force: :cascade do |t|
-    t.integer "number"
     t.text "project_title"
     t.string "donors", null: false
     t.string "status", null: false

--- a/lib/tasks/import_projects.rake
+++ b/lib/tasks/import_projects.rake
@@ -8,7 +8,7 @@ namespace :import do
     csv_headers = File.readlines(csv).first.split(",")
 
     project_hash = {
-      number: csv_headers[0],
+      id: csv_headers[0],
       project_title: csv_headers[1],
       donors: csv_headers[2],
       status: csv_headers[3],
@@ -29,7 +29,7 @@ namespace :import do
       project_row = row.to_hash
 
       project = Project.new
-      project.number = project_row[project_hash[:number]].to_i
+      project.id = project_row[project_hash[:id]].to_i
       project.project_title = project_row[project_hash[:project_title]]
       project.donors = project_row[project_hash[:donors]] || "Empty"
       project.status = project_row[project_hash[:status]] || "Empty"


### PR DESCRIPTION
I have removed the number column as we do not need it. I have removed it from the migration and also from within the import_projects rake task.