### PR TITLE
Replaced comma with semicolon to fix broken import

### DIFF
--- a/lib/tasks/import_projects.rake
+++ b/lib/tasks/import_projects.rake
@@ -49,7 +49,7 @@ namespace :import do
       fields.each do |field|
         list_of_children = project_row[project_hash[field.to_sym]]&.strip
         next if list_of_children.nil?
-        list_of_children = list_of_children.split(",")
+        list_of_children = list_of_children.split(";")
         list_of_children.each do |child_name|
           new_child = field.camelize.singularize.constantize.find_or_create_by(name: child_name)
           unless project.send(field.downcase.to_sym).exists?(new_child.id)


### PR DESCRIPTION
Fixed a huge problem with the import, as there was a change from a comma to a semicolon.
This has been tested and works now! To fix this it is necessary to first drop the database, recreate it and run the rake import project task again.