### PR TITLE
Remove whitespace from child_name using strip

### DIFF
--- a/lib/tasks/import_projects.rake
+++ b/lib/tasks/import_projects.rake
@@ -51,6 +51,7 @@ namespace :import do
         next if list_of_children.nil?
         list_of_children = list_of_children.split(";")
         list_of_children.each do |child_name|
+          child_name = child_name&.strip
           new_child = field.camelize.singularize.constantize.find_or_create_by(name: child_name)
           unless project.send(field.downcase.to_sym).exists?(new_child.id)
             project.send(field.downcase.to_sym) << new_child


### PR DESCRIPTION
Fixed a problem with duplicate data due to whitespace which should not be allowed through into the database, by using the Ruby `strip` method.